### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ _unit-tests: &unit-tests
   sudo: required
   services: docker
   script:
-    - ./mnnw test -B
+    - ./mvnw test -B
 
 ### Futur Job pour les tests fonctionnels
 #_functional-tests: &functional-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+### Job pour les tests unitaires
+_unit-tests: &unit-tests
+  os: linux
+  sudo: required
+  services: docker
+  script:
+    - ./mnnw test -B
+
+### Futur Job pour les tests fonctionnels
+#_functional-tests: &functional-tests
+#  os: linux
+#  sudo: required
+#  services: docker
+#  script:
+#    - commande pour lancer les tests avec squach
+
+
+### Job de deploy : Pour l'instant ca met a jour l'image docker automatiquement si les tests reussissent et si on push sur master
+_app-deploy: &app-deploy
+  stage: Deployments
+  language: minimal
+  services: docker
+  if: type=push AND branch=master
+  script:
+    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - docker build . -t $IMAGE_NAME
+    - docker push $IMAGE_NAME:latest
+
+jobs:
+  include:
+    - <<: *unit-tests
+      stage: Unit tests
+      name: Unit Tests
+
+#    - <<: *functional-tests
+#      stage: functional tests
+#      name: functional Tests
+
+    - <<: *app-deploy
+      stage: Deployments
+      name: Deployment

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://..
+spring.datasource.username=//..
+spring.datasource.password=//..


### PR DESCRIPTION
This PR adds Travis CI with the following job

- Unit Test
- Functional test (to come)
- Auto update and deployment of docker image

It still doesnt run because `application.properties` file must be filled with database credentials.

Travis will update and push the new docker image on DockerHub ONLY if the push is on master and tests succeed